### PR TITLE
Small typo in Exception Text in cpufreq.py

### DIFF
--- a/cpufreq/cpufreq.py
+++ b/cpufreq/cpufreq.py
@@ -55,10 +55,10 @@ class cpuFreq:
                                                "cpufreq",
                                                "scaling_driver"))
             if not LINUX:
-                raise CPUFreqErrorInit("ERROR: %s Class should be used only"
+                raise CPUFreqErrorInit("ERROR: %s Class should be used only "
                                        "on Linux Systems." % cls.__name__)
             elif not DRIVERFREQ:
-                raise CPUFreqErrorInit("ERROR: %s Class should be used only"
+                raise CPUFreqErrorInit("ERROR: %s Class should be used only "
                                        "with OS CPU Power driver activated (Linux ACPI "
                                        "module, for example)." % cls.__name__)
             else:


### PR DESCRIPTION
In line 58 and 61, space wasn't provided at the end of the line.
![Screenshot 2020-10-22 at 9 37 01 AM](https://user-images.githubusercontent.com/60005847/96823433-253fb680-144a-11eb-856f-3fe1688400cd.png)
It can be seen as shown above " ... used **onlyon** linux ...."